### PR TITLE
Adopt spades v4

### DIFF
--- a/.github/environments/fluviewer-bccdc-phl.yml
+++ b/.github/environments/fluviewer-bccdc-phl.yml
@@ -1,0 +1,18 @@
+name: fluviewer-bccdc-phl
+channels:
+  - bioconda
+  - conda-forge
+  - defaults
+dependencies:
+  - bbmap=39.01
+  - bcftools=1.17
+  - blast=2.14.1
+  - bwa=0.7.17
+  - samtools=1.17
+  - spades=4.0.0
+  - clustalw=2.1
+  - freebayes=1.3.6
+  - python=3
+  - pip
+  - pandas=2.0.3
+  - seaborn=0.12.2

--- a/.github/environments/fluviewer-kkuchinski.yml
+++ b/.github/environments/fluviewer-kkuchinski.yml
@@ -12,9 +12,10 @@ dependencies:
   - spades=3.15.3
   - clustalw=2.1
   - freebayes=1.3.6
-  - python=3
+  - python=3.9
+  - setuptools=69
   - pip
-  - pandas=2.0.3
-  - seaborn=0.12.2
+  - pandas=2.0
+  - seaborn=0.12
   - pip:
     - FluViewer==0.1.11

--- a/.github/environments/fluviewer-kkuchinski.yml
+++ b/.github/environments/fluviewer-kkuchinski.yml
@@ -1,0 +1,20 @@
+name: fluviewer-kkuchinski
+channels:
+  - bioconda
+  - conda-forge
+  - defaults
+dependencies:
+  - bbmap=39.01
+  - bcftools=1.17
+  - blast=2.14.1
+  - bwa=0.7.17
+  - samtools=1.17
+  - spades=3.15.3
+  - clustalw=2.1
+  - freebayes=1.3.6
+  - python=3
+  - pip
+  - pandas=2.0.3
+  - seaborn=0.12.2
+  - pip:
+    - FluViewer==0.1.11

--- a/.github/scripts/install_fluviewer_bccdc-phl.sh
+++ b/.github/scripts/install_fluviewer_bccdc-phl.sh
@@ -4,7 +4,7 @@ source ${HOME}/.bashrc
  
 eval "$(conda shell.bash hook)"
 
-conda env create -f environment.yaml -n fluviewer-bccdc-phl
+conda env create -f .github/environments/fluviewer-bccdc-phl.yml -n fluviewer-bccdc-phl
 
 conda activate fluviewer-bccdc-phl
 

--- a/.github/scripts/install_fluviewer_kkuchinski.sh
+++ b/.github/scripts/install_fluviewer_kkuchinski.sh
@@ -6,8 +6,4 @@ eval "$(conda shell.bash hook)"
 
 fluviewer_version="0.1.11"
 
-conda env create -f environment.yaml -n fluviewer-kkuchinski
-
-conda activate fluviewer-kkuchinski
-
-pip install fluviewer==${fluviewer_version}
+conda env create -f .github/environments/fluviewer-kkuchinski.yml -n fluviewer-kkuchinski

--- a/environment.yaml
+++ b/environment.yaml
@@ -9,7 +9,7 @@ dependencies:
   - blast=2.14.1
   - bwa=0.7.17
   - samtools=1.17
-  - spades=3.15.3
+  - spades=4.0.0
   - clustalw=2.1
   - freebayes=1.3.6
   - python=3

--- a/fluviewer/analysis.py
+++ b/fluviewer/analysis.py
@@ -235,7 +235,7 @@ def assemble_contigs(
 
     os.makedirs(spades_output, exist_ok=True)
 
-    terminal_command = (f'spades.py --rnaviral --isolate -1 {fwd_reads} '
+    terminal_command = (f'spades.py --rnaviral -1 {fwd_reads} '
                         f'-2 {rev_reads} -o {spades_output}')
 
     process_name = 'spades'


### PR DESCRIPTION
Fixes #37 

Removed the `--isolate` flag from our spades command because it's incompatible with `--rnaviral` in spades v4.

We should evaluate this on more samples before merging, so ensure that using this newer version of spades doesn't significantly impact the assemblies and the overall consensus sequence generation & variant calling processes.

Our "consistency check" should help with that, but we need to look at a broader range of real samples to be sure.